### PR TITLE
Wire in deployed WebSocket URL for online Bananagrams

### DIFF
--- a/bananagrams-online/config.js
+++ b/bananagrams-online/config.js
@@ -11,4 +11,4 @@
 // Then copy the "WebSocketURL" output value below.
 // Example: wss://abc123xyz.execute-api.us-east-1.amazonaws.com/prod
 
-const WS_URL = 'wss://REPLACE_WITH_YOUR_WEBSOCKET_URL.execute-api.us-east-1.amazonaws.com/prod';
+const WS_URL = 'wss://51obau5kch.execute-api.us-east-1.amazonaws.com/prod';


### PR DESCRIPTION
## Summary

- Updates `bananagrams-online/config.js` with the live WebSocket URL from the deployed AWS backend
- The `bananagrams-backend` CloudFormation stack is deployed in `us-east-1` under account `066281862067`

## Deployed resources

| Resource | Value |
|---|---|
| CloudFormation stack | `bananagrams-backend` |
| WebSocket endpoint | `wss://51obau5kch.execute-api.us-east-1.amazonaws.com/prod` |
| DynamoDB tables | `bananagrams-games`, `bananagrams-connections` |

## Test plan

- [ ] Open `ericmanzi.github.io/bananagrams-online/` in two separate browser tabs or devices
- [ ] Create a room in one tab, copy the 6-letter code
- [ ] Join with the code in the second tab — both should see the game start with 21 tiles each
- [ ] Verify PEEL draws one tile for each player simultaneously
- [ ] Verify DUMP swaps one tile for three (opponent unaffected)
- [ ] Verify win condition fires when bunch runs out and a player peels with empty hand

https://claude.ai/code/session_01FsE6JrrWRw7cethtN82qJc

---
_Generated by [Claude Code](https://claude.ai/code/session_01FsE6JrrWRw7cethtN82qJc)_