### PR TITLE
Add game pause/resume and player rejoin functionality

### DIFF
--- a/backend/__tests__/handler.test.js
+++ b/backend/__tests__/handler.test.js
@@ -110,7 +110,7 @@ describe('$disconnect', () => {
     expect(apigwMock.commandCalls(PostToConnectionCommand)).toHaveLength(0);
   });
 
-  test('notifies opponent and marks game abandoned when player disconnects mid-game', async () => {
+  test('notifies opponent and marks game paused when player disconnects mid-game', async () => {
     ddbMock
       .on(GetItemCommand)
       .resolvesOnce({ Item: marshalConn({ connectionId: 'host-conn', roomCode: 'ROOM01', role: 'host' }) })
@@ -125,9 +125,31 @@ describe('$disconnect', () => {
     expect(msgs).toHaveLength(1);
     expect(msgs[0].type).toBe('OPPONENT_DISCONNECTED');
 
-    // Game status should be updated to 'abandoned'
+    // Game status should be updated to 'paused' with pausedRole = 'host'
     const updates = ddbMock.commandCalls(UpdateItemCommand);
     expect(updates).toHaveLength(1);
+    const vals = updates[0].args[0].input.ExpressionAttributeValues;
+    expect(vals[':s']).toEqual({ S: 'paused' });
+    expect(vals[':pr']).toEqual({ S: 'host' });
+  });
+
+  test('marks game abandoned when second player disconnects from an already-paused game', async () => {
+    ddbMock
+      .on(GetItemCommand)
+      .resolvesOnce({ Item: marshalConn({ connectionId: 'guest-conn', roomCode: 'ROOM01', role: 'guest' }) })
+      .resolvesOnce({ Item: marshalGame({ status: 'paused', pausedRole: 'host', guestConnectionId: 'guest-conn' }) })
+      .on(UpdateItemCommand).resolves({})
+      .on(DeleteItemCommand).resolves({});
+
+    await handler(event('$disconnect', 'guest-conn'));
+
+    // No WebSocket message needed (disconnected player has no live connection)
+    expect(apigwMock.commandCalls(PostToConnectionCommand)).toHaveLength(0);
+
+    const updates = ddbMock.commandCalls(UpdateItemCommand);
+    expect(updates).toHaveLength(1);
+    const vals = updates[0].args[0].input.ExpressionAttributeValues;
+    expect(vals[':s']).toEqual({ S: 'abandoned' });
   });
 
   test('does not notify anyone if the game is already finished', async () => {
@@ -483,6 +505,107 @@ describe('ping', () => {
     expect(result.statusCode).toBe(200);
     expect(ddbMock.commandCalls(GetItemCommand)).toHaveLength(0);
     expect(apigwMock.commandCalls(PostToConnectionCommand)).toHaveLength(0);
+  });
+});
+
+// ── rejoinRoom ────────────────────────────────────────────────────────────────
+
+describe('rejoinRoom', () => {
+  const HOST_HAND  = [{ id: 0, letter: 'A' }, { id: 1, letter: 'B' }];
+  const GUEST_HAND = [{ id: 2, letter: 'C' }];
+  const BUNCH_TILE = { id: 99, letter: 'Z' };
+
+  const pausedGame = (overrides = {}) => marshalGame({
+    status:            'paused',
+    pausedRole:        'host',
+    hostConnectionId:  'old-host-conn',
+    guestConnectionId: 'guest-conn',
+    hostHand:          HOST_HAND,
+    guestHand:         GUEST_HAND,
+    bunch:             [BUNCH_TILE],
+    ...overrides,
+  });
+
+  test('sends REJOIN_OK with stored hand and bunch size to the rejoining player', async () => {
+    ddbMock
+      .on(GetItemCommand).resolves({ Item: pausedGame() })
+      .on(UpdateItemCommand).resolves({});
+
+    await handler(event('$default', 'new-host-conn', { action: 'rejoinRoom', roomCode: 'ROOM01', role: 'host' }));
+
+    const msgs = msgsTo('new-host-conn');
+    const ok   = msgs.find(m => m.type === 'REJOIN_OK');
+    expect(ok).toBeDefined();
+    expect(ok.hand).toEqual(HOST_HAND);
+    expect(ok.bunchSize).toBe(1);
+    expect(ok.role).toBe('host');
+    expect(ok.roomCode).toBe('ROOM01');
+  });
+
+  test('notifies the waiting opponent when player rejoins', async () => {
+    ddbMock
+      .on(GetItemCommand).resolves({ Item: pausedGame() })
+      .on(UpdateItemCommand).resolves({});
+
+    await handler(event('$default', 'new-host-conn', { action: 'rejoinRoom', roomCode: 'ROOM01', role: 'host' }));
+
+    const guestMsgs = msgsTo('guest-conn');
+    expect(guestMsgs.find(m => m.type === 'OPPONENT_RECONNECTED')).toBeDefined();
+  });
+
+  test('updates the player connection ID and marks game playing again', async () => {
+    ddbMock
+      .on(GetItemCommand).resolves({ Item: pausedGame() })
+      .on(UpdateItemCommand).resolves({});
+
+    await handler(event('$default', 'new-host-conn', { action: 'rejoinRoom', roomCode: 'ROOM01', role: 'host' }));
+
+    const updates = ddbMock.commandCalls(UpdateItemCommand);
+    const gameUpdate = updates.find(u => {
+      const vals = u.args[0].input.ExpressionAttributeValues;
+      return vals?.[':s']?.S === 'playing';
+    });
+    expect(gameUpdate).toBeDefined();
+    expect(gameUpdate.args[0].input.ExpressionAttributeValues[':cid']).toEqual({ S: 'new-host-conn' });
+  });
+
+  test('sends guest hand when guest rejoins', async () => {
+    ddbMock
+      .on(GetItemCommand).resolves({ Item: pausedGame({ pausedRole: 'guest' }) })
+      .on(UpdateItemCommand).resolves({});
+
+    await handler(event('$default', 'new-guest-conn', { action: 'rejoinRoom', roomCode: 'ROOM01', role: 'guest' }));
+
+    const ok = msgsTo('new-guest-conn').find(m => m.type === 'REJOIN_OK');
+    expect(ok).toBeDefined();
+    expect(ok.hand).toEqual(GUEST_HAND);
+    expect(ok.role).toBe('guest');
+  });
+
+  test('sends ERROR when game is not found', async () => {
+    ddbMock.on(GetItemCommand).resolves({ Item: undefined });
+
+    await handler(event('$default', 'new-conn', { action: 'rejoinRoom', roomCode: 'BADROOM', role: 'host' }));
+
+    expect(msgsTo('new-conn')[0].type).toBe('ERROR');
+    expect(msgsTo('new-conn')[0].message).toMatch(/not found/i);
+  });
+
+  test('sends ERROR when game is not paused', async () => {
+    ddbMock.on(GetItemCommand).resolves({ Item: marshalGame({ status: 'playing' }) });
+
+    await handler(event('$default', 'new-conn', { action: 'rejoinRoom', roomCode: 'ROOM01', role: 'host' }));
+
+    expect(msgsTo('new-conn')[0].type).toBe('ERROR');
+  });
+
+  test('sends ERROR when the rejoining role does not match the disconnected role', async () => {
+    ddbMock.on(GetItemCommand).resolves({ Item: pausedGame({ pausedRole: 'guest' }) });
+
+    await handler(event('$default', 'new-conn', { action: 'rejoinRoom', roomCode: 'ROOM01', role: 'host' }));
+
+    expect(msgsTo('new-conn')[0].type).toBe('ERROR');
+    expect(msgsTo('new-conn')[0].message).toMatch(/not the disconnected player/i);
   });
 });
 

--- a/backend/handler.js
+++ b/backend/handler.js
@@ -97,7 +97,16 @@ exports.handler = async (event) => {
           if (opponentConnId) {
             await send(opponentConnId, { type: 'OPPONENT_DISCONNECTED' });
           }
-          // Mark game finished so no further actions are accepted
+          // Mark game paused so the opponent waits while the player can rejoin
+          await dynamo.send(new UpdateItemCommand({
+            TableName: GAMES_TABLE,
+            Key: marshall({ roomCode: conn.roomCode }),
+            UpdateExpression: 'SET #s = :s, pausedRole = :pr',
+            ExpressionAttributeNames: { '#s': 'status' },
+            ExpressionAttributeValues: marshall({ ':s': 'paused', ':pr': conn.role }),
+          }));
+        } else if (game && game.status === 'paused') {
+          // Both players gone — abandon the game
           await dynamo.send(new UpdateItemCommand({
             TableName: GAMES_TABLE,
             Key: marshall({ roomCode: conn.roomCode }),
@@ -176,7 +185,7 @@ exports.handler = async (event) => {
         await dynamo.send(new UpdateItemCommand({
           TableName: GAMES_TABLE,
           Key: marshall({ roomCode }),
-          UpdateExpression: 'SET #s = :playing, bunch = :bunch, guestConnectionId = :gid, #ttl = :ttl',
+          UpdateExpression: 'SET #s = :playing, bunch = :bunch, guestConnectionId = :gid, #ttl = :ttl, hostHand = :hh, guestHand = :gh',
           ConditionExpression: '#s = :waiting',
           ExpressionAttributeNames: { '#s': 'status', '#ttl': 'ttl' },
           ExpressionAttributeValues: marshall({
@@ -185,6 +194,8 @@ exports.handler = async (event) => {
             ':bunch': bunch,
             ':gid': connectionId,
             ':ttl': ttl(),
+            ':hh': hostHand,
+            ':gh': guestHand,
           }),
         }));
       } catch (err) {
@@ -238,8 +249,8 @@ exports.handler = async (event) => {
       await dynamo.send(new UpdateItemCommand({
         TableName: GAMES_TABLE,
         Key: marshall({ roomCode }),
-        UpdateExpression: 'SET bunch = :b',
-        ExpressionAttributeValues: marshall({ ':b': newBunch }),
+        UpdateExpression: 'SET bunch = :b, hostHand = list_append(if_not_exists(hostHand, :empty), :ht), guestHand = list_append(if_not_exists(guestHand, :empty), :gt)',
+        ExpressionAttributeValues: marshall({ ':b': newBunch, ':empty': [], ':ht': [hostTile], ':gt': [guestTile] }),
       }));
 
       await send(hostConnectionId,  { type: 'PEEL_RESULT', tile: hostTile,  bunchSize: newBunch.length, initiator: role });
@@ -264,11 +275,15 @@ exports.handler = async (event) => {
       const newTiles = bunch.slice(0, 3);
       const newBunch = shuffle([...bunch.slice(3), tile]);
 
+      const callerHand = (role === 'host' ? game.hostHand : game.guestHand) || [];
+      const updatedCallerHand = [...callerHand.filter(t => t.id !== tile.id), ...newTiles];
+      const callerHandAttr = role === 'host' ? 'hostHand' : 'guestHand';
+
       await dynamo.send(new UpdateItemCommand({
         TableName: GAMES_TABLE,
         Key: marshall({ roomCode }),
-        UpdateExpression: 'SET bunch = :b',
-        ExpressionAttributeValues: marshall({ ':b': newBunch }),
+        UpdateExpression: `SET bunch = :b, ${callerHandAttr} = :uh`,
+        ExpressionAttributeValues: marshall({ ':b': newBunch, ':uh': updatedCallerHand }),
       }));
 
       await send(callerConnId, {
@@ -278,6 +293,51 @@ exports.handler = async (event) => {
         removedLetter: tile.letter,
         bunchSize: newBunch.length,
       });
+      return { statusCode: 200 };
+    }
+
+    // rejoinRoom ──────────────────────────────────────────────────────────────
+    if (action === 'rejoinRoom') {
+      const { roomCode, role } = body;
+      const game = await getGame(roomCode);
+
+      if (!game) {
+        await send(connectionId, { type: 'ERROR', message: 'Room not found. The game may have expired.' });
+        return { statusCode: 200 };
+      }
+      if (game.status !== 'paused') {
+        await send(connectionId, { type: 'ERROR', message: 'This game is not waiting for a rejoin.' });
+        return { statusCode: 200 };
+      }
+      if (game.pausedRole !== role) {
+        await send(connectionId, { type: 'ERROR', message: 'You are not the disconnected player for this room.' });
+        return { statusCode: 200 };
+      }
+
+      const hand = (role === 'host' ? game.hostHand : game.guestHand) || [];
+      const opponentConnId = role === 'host' ? game.guestConnectionId : game.hostConnectionId;
+      const connIdAttr = role === 'host' ? 'hostConnectionId' : 'guestConnectionId';
+
+      await dynamo.send(new UpdateItemCommand({
+        TableName: GAMES_TABLE,
+        Key: marshall({ roomCode }),
+        UpdateExpression: `SET #s = :s, ${connIdAttr} = :cid REMOVE pausedRole`,
+        ExpressionAttributeNames: { '#s': 'status' },
+        ExpressionAttributeValues: marshall({ ':s': 'playing', ':cid': connectionId }),
+      }));
+
+      await dynamo.send(new UpdateItemCommand({
+        TableName: CONNS_TABLE,
+        Key: marshall({ connectionId }),
+        UpdateExpression: 'SET roomCode = :rc, #r = :role',
+        ExpressionAttributeNames: { '#r': 'role' },
+        ExpressionAttributeValues: marshall({ ':rc': roomCode, ':role': role }),
+      }));
+
+      await send(connectionId, { type: 'REJOIN_OK', hand, bunchSize: game.bunch.length, role, roomCode });
+      if (opponentConnId) {
+        await send(opponentConnId, { type: 'OPPONENT_RECONNECTED' });
+      }
       return { statusCode: 200 };
     }
 

--- a/bananagrams-online/game.js
+++ b/bananagrams-online/game.js
@@ -6,6 +6,17 @@ const GRID_SIZE = 25;
 const DICTIONARY_URL = 'https://raw.githubusercontent.com/dwyl/english-words/master/words_alpha.txt';
 const baseFont = "system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif";
 const PING_INTERVAL_MS = 8 * 60 * 1000; // 8 min — keeps API GW connection alive
+const ONLINE_STORAGE_KEY = 'bananagrams_online_state';
+
+function saveOnlineState(state) {
+  try { localStorage.setItem(ONLINE_STORAGE_KEY, JSON.stringify(state)); } catch (e) {}
+}
+function loadOnlineState() {
+  try { const s = localStorage.getItem(ONLINE_STORAGE_KEY); return s ? JSON.parse(s) : null; } catch (e) { return null; }
+}
+function clearOnlineState() {
+  try { localStorage.removeItem(ONLINE_STORAGE_KEY); } catch (e) {}
+}
 
 // ── Utilities ────────────────────────────────────────────────────────────────
 
@@ -143,6 +154,7 @@ function OnlineBananagrams() {
   const [dictionary, setDictionary] = useState(null);
   const [dictLoading, setDictLoading] = useState(true);
   const [copied, setCopied] = useState(false);
+  const [savedOnline, setSavedOnline] = useState(null);
 
   // refs for use inside WS callbacks (avoid stale closures)
   const wsRef       = useRef(null);
@@ -172,6 +184,21 @@ function OnlineBananagrams() {
       })
       .catch(() => setDictLoading(false));
   }, []);
+
+  // Refresh savedOnline from localStorage whenever we arrive at the menu screen
+  useEffect(() => {
+    if (screen === 'menu') {
+      const saved = loadOnlineState();
+      setSavedOnline(saved?.roomCode ? saved : null);
+    }
+  }, [screen]);
+
+  // Persist hand + grid + timer to localStorage while playing so rejoin can restore them
+  useEffect(() => {
+    if (screen === 'playing' && roomCode && role) {
+      saveOnlineState({ roomCode, role, hand, grid, timer });
+    }
+  }, [hand, grid, screen, roomCode, role, timer]);
 
   // cleanup on unmount
   useEffect(() => () => {
@@ -280,8 +307,36 @@ function OnlineBananagrams() {
         break;
 
       case 'OPPONENT_DISCONNECTED':
-        showMsg('⚠️ Opponent disconnected. Waiting for them to rejoin is not yet supported — press Quit to return to the menu.', 0);
+        showMsg('⏳ Opponent disconnected — game paused. Waiting for them to rejoin…', 0);
         break;
+
+      case 'OPPONENT_RECONNECTED':
+        showMsg('✅ Opponent reconnected! Game resumes.', 3000);
+        break;
+
+      case 'REJOIN_OK': {
+        setRole(data.role);
+        roleRef.current = data.role;
+        // Use hand from server (authoritative); fall back to locally-saved hand
+        const restoredHand = data.hand?.length > 0 ? data.hand : (loadOnlineState()?.hand || []);
+        setHand(restoredHand);
+        handRef.current = restoredHand;
+        setBunchSize(data.bunchSize);
+        if (data.roomCode) { setRoomCode(data.roomCode); roomRef.current = data.roomCode; }
+        // Restore grid from localStorage (only the client knows where tiles were placed)
+        const savedForGrid = loadOnlineState();
+        const restoredGrid = savedForGrid?.grid || createEmptyGrid();
+        setGrid(restoredGrid);
+        gridRef.current = restoredGrid;
+        setSelected(null);
+        setGameResult(null);
+        setOpponent({ handSize: 0, wordCount: 0 });
+        setMessage('');
+        setScreen('playing');
+        startTimer();
+        startPing();
+        break;
+      }
 
       case 'ERROR':
         setConnError(data.message || 'An error occurred.');
@@ -305,8 +360,10 @@ function OnlineBananagrams() {
     ws.onerror   = () => { setConnError('Could not reach the game server. Check your connection and try again.'); setScreen('error'); };
     ws.onclose   = () => {
       clearInterval(pingRef.current);
-      if (screenRef.current === 'playing' || screenRef.current === 'waiting')
-        showMsg('⚠️ Connection lost. Please refresh and try again.', 0);
+      // Return to menu so the player sees the Rejoin button (state is saved in localStorage)
+      if (screenRef.current === 'playing' || screenRef.current === 'waiting') {
+        setScreen('menu');
+      }
     };
   };
 
@@ -325,6 +382,7 @@ function OnlineBananagrams() {
   const resetToMenu = () => {
     clearInterval(timerRef.current);
     clearInterval(pingRef.current);
+    clearOnlineState();
     wsRef.current?.close();
     wsRef.current = null;
     setScreen('menu');
@@ -337,6 +395,16 @@ function OnlineBananagrams() {
     setSelected(null);
     setMessage('');
     setTimer(0);
+  };
+
+  const rejoinSavedGame = () => {
+    const saved = loadOnlineState();
+    if (!saved) return;
+    const { roomCode: rc, role: r } = saved;
+    setRoomCode(rc);
+    roomRef.current = rc;
+    setScreen('connecting');
+    openWS(() => wsSend({ action: 'rejoinRoom', roomCode: rc, role: r }));
   };
 
   // ── Game actions ───────────────────────────────────────────────────────────
@@ -407,6 +475,11 @@ function OnlineBananagrams() {
           <p style={S.subtitle}>Online Multiplayer</p>
 
           <div style={{ display: 'flex', flexDirection: 'column', gap: '12px', marginBottom: '24px' }}>
+            {savedOnline && (
+              <button onClick={rejoinSavedGame} style={S.btn('linear-gradient(145deg, #e67e22, #d35400)', '#a04000')}>
+                ↩ Rejoin {savedOnline.roomCode}
+              </button>
+            )}
             <button onClick={createRoom} style={S.btn('linear-gradient(145deg, #4CAF50, #45a049)', '#2E7D32')}>
               Create Room
             </button>


### PR DESCRIPTION
## Summary
This PR implements a pause/resume system for online multiplayer games, allowing players to reconnect and resume a game after an unexpected disconnection instead of losing progress.

## Key Changes

**Backend (handler.js)**
- Modified disconnect handler to mark games as "paused" (instead of "abandoned") when a player disconnects mid-game, storing which role disconnected via `pausedRole`
- Only mark game as "abandoned" when the second player disconnects from an already-paused game
- Added new `rejoinRoom` action that allows a disconnected player to reconnect to their paused game
- Updated `joinRoom` and `peel` actions to persist player hands to the database for recovery on rejoin
- Updated `drawTiles` action to track hand state in the database

**Frontend (game.js)**
- Added localStorage persistence for online game state (room code, role, hand, grid, timer) to survive page refreshes
- Added `saveOnlineState()`, `loadOnlineState()`, and `clearOnlineState()` utility functions
- Added "Rejoin" button on menu screen when a saved game state exists
- Implemented `rejoinSavedGame()` to reconnect to a paused game
- Updated WebSocket message handlers to support `REJOIN_OK` and `OPPONENT_RECONNECTED` messages
- Modified disconnect behavior to return to menu (showing rejoin option) instead of showing error
- Updated opponent disconnect message to indicate game is paused and waiting for rejoin
- Clear saved state when player explicitly quits to menu

**Tests**
- Updated disconnect test to verify game is marked "paused" with correct `pausedRole`
- Added test for marking game "abandoned" when second player disconnects from paused game
- Added comprehensive test suite for `rejoinRoom` action covering success cases and error scenarios

## Implementation Details
- Game state is stored in DynamoDB with `status: 'paused'` and `pausedRole` attribute to track which player disconnected
- Player hands are persisted in the database (`hostHand`, `guestHand`) to ensure authoritative state on rejoin
- Client-side localStorage serves as a fallback for grid state (which is client-only) and provides quick access to rejoin information
- The rejoin flow validates that the reconnecting player matches the role that originally disconnected

https://claude.ai/code/session_014Dg8aB1HrewQySNduVHBn7