### PR TITLE
fix(bananagrams-online): escape 'connecting' screen on rejoin failure

### DIFF
--- a/bananagrams-online/game.js
+++ b/bananagrams-online/game.js
@@ -360,9 +360,13 @@ function OnlineBananagrams() {
     ws.onerror   = () => { setConnError('Could not reach the game server. Check your connection and try again.'); setScreen('error'); };
     ws.onclose   = () => {
       clearInterval(pingRef.current);
-      // Return to menu so the player sees the Rejoin button (state is saved in localStorage)
-      if (screenRef.current === 'playing' || screenRef.current === 'waiting') {
+      const s = screenRef.current;
+      if (s === 'playing' || s === 'waiting') {
         setScreen('menu');
+      } else if (s === 'connecting') {
+        // WS closed before we got a response — surface an error rather than hanging
+        setConnError('Connection closed before the game could start. Check your connection and try again.');
+        setScreen('error');
       }
     };
   };
@@ -405,6 +409,15 @@ function OnlineBananagrams() {
     roomRef.current = rc;
     setScreen('connecting');
     openWS(() => wsSend({ action: 'rejoinRoom', roomCode: rc, role: r }));
+    // If the server doesn't reply within 8 s (e.g. backend not yet redeployed),
+    // stop waiting and show a clear error instead of hanging on 'connecting'.
+    setTimeout(() => {
+      if (screenRef.current !== 'connecting') return;
+      wsRef.current?.close();
+      clearOnlineState();
+      setConnError('No response from the server — the session may have expired. Start a new game.');
+      setScreen('error');
+    }, 8000);
   };
 
   // ── Game actions ───────────────────────────────────────────────────────────


### PR DESCRIPTION
Two bugs caused an infinite spinner when a rejoin attempt failed:

1. ws.onclose only redirected for 'playing'/'waiting' screens. If the socket closed during the 'connecting' phase (server error, unexpected close) the screen never advanced. Now redirects to the error screen for 'connecting' as well.

2. No timeout on the rejoin request. If the backend received the rejoinRoom message but sent no reply (e.g. lambda not yet redeployed with the new handler), the socket stayed open indefinitely. An 8 s timeout now closes the socket, clears saved state, and shows a clear "session may have expired" error instead.

https://claude.ai/code/session_014Dg8aB1HrewQySNduVHBn7