### PR TITLE
fix(bananagrams-online): bug fixes + rejoin fix + remove words panel

### DIFF
--- a/backend/__tests__/handler.test.js
+++ b/backend/__tests__/handler.test.js
@@ -210,6 +210,17 @@ describe('createRoom', () => {
     expect(result.statusCode).toBe(200);
     expect(msgsTo('host-conn')[0].type).toBe('ROOM_CREATED');
   });
+
+  test('sends ERROR when both generated room codes collide with live games', async () => {
+    ddbMock
+      .on(GetItemCommand)
+      .resolvesOnce({ Item: marshalGame({ status: 'waiting' }) })   // first code: collision
+      .resolvesOnce({ Item: marshalGame({ status: 'playing' }) });  // second code: also collision
+
+    const result = await handler(event('$default', 'host-conn', { action: 'createRoom' }));
+    expect(result.statusCode).toBe(200);
+    expect(msgsTo('host-conn')[0].type).toBe('ERROR');
+  });
 });
 
 // ── joinRoom ──────────────────────────────────────────────────────────────────
@@ -380,6 +391,8 @@ describe('dump', () => {
     status:            'playing',
     hostConnectionId:  'host-conn',
     guestConnectionId: 'guest-conn',
+    hostHand:          [RETURNED_TILE],
+    guestHand:         [RETURNED_TILE],
     bunch,
   });
 
@@ -600,6 +613,11 @@ describe('rejoinRoom', () => {
   });
 
   test('allows rejoin when game status is still playing (missed $disconnect)', async () => {
+    // Probe to the old connection must 410 before rejoin is permitted
+    apigwMock
+      .on(PostToConnectionCommand)
+      .rejectsOnce(Object.assign(new Error('Gone'), { $metadata: { httpStatusCode: 410 } }))
+      .resolves({});
     ddbMock
       .on(GetItemCommand).resolves({ Item: pausedGame({ status: 'playing', pausedRole: null }) })
       .on(UpdateItemCommand).resolves({});
@@ -609,6 +627,18 @@ describe('rejoinRoom', () => {
     const ok = msgsTo('new-host-conn').find(m => m.type === 'REJOIN_OK');
     expect(ok).toBeDefined();
     expect(ok.hand).toEqual(HOST_HAND);
+  });
+
+  test('sends ERROR when the claimed role connection is still alive (playing game)', async () => {
+    // Default apigwMock resolves (connection alive) — no override needed
+    ddbMock
+      .on(GetItemCommand).resolves({ Item: pausedGame({ status: 'playing', pausedRole: null }) });
+
+    await handler(event('$default', 'new-host-conn', { action: 'rejoinRoom', roomCode: 'ROOM01', role: 'host' }));
+
+    const msgs = msgsTo('new-host-conn');
+    expect(msgs[0].type).toBe('ERROR');
+    expect(msgs[0].message).toMatch(/still connected/i);
   });
 
   test('sends ERROR when the rejoining role does not match the disconnected role', async () => {

--- a/backend/handler.js
+++ b/backend/handler.js
@@ -130,10 +130,14 @@ exports.handler = async (event) => {
     // createRoom ──────────────────────────────────────────────────────────────
     if (action === 'createRoom') {
       let roomCode = generateRoomCode();
-      // Retry once on collision (astronomically rare at our traffic levels)
-      const existing = await getGame(roomCode);
+      let existing = await getGame(roomCode);
       if (existing && existing.status !== 'finished' && existing.status !== 'abandoned') {
         roomCode = generateRoomCode();
+        existing = await getGame(roomCode);
+        if (existing && existing.status !== 'finished' && existing.status !== 'abandoned') {
+          await send(connectionId, { type: 'ERROR', message: 'Could not generate a unique room code. Please try again.' });
+          return { statusCode: 200 };
+        }
       }
 
       await dynamo.send(new PutItemCommand({
@@ -228,6 +232,11 @@ exports.handler = async (event) => {
 
       const { bunch, hostConnectionId, guestConnectionId } = game;
 
+      // Verify the caller is who they claim to be
+      if (connectionId !== (role === 'host' ? hostConnectionId : guestConnectionId)) {
+        return { statusCode: 200 };
+      }
+
       if (bunch.length < NUM_PLAYERS) {
         // Caller wins — not enough tiles for everyone
         await dynamo.send(new UpdateItemCommand({
@@ -242,16 +251,24 @@ exports.handler = async (event) => {
         return { statusCode: 200 };
       }
 
-      const hostTile  = bunch[0];
-      const guestTile = bunch[1];
-      const newBunch  = bunch.slice(2);
+      const hostTile    = bunch[0];
+      const guestTile   = bunch[1];
+      const newBunch    = bunch.slice(2);
+      const peelVersion = game.peelVersion ?? -1;
 
-      await dynamo.send(new UpdateItemCommand({
-        TableName: GAMES_TABLE,
-        Key: marshall({ roomCode }),
-        UpdateExpression: 'SET bunch = :b, hostHand = list_append(if_not_exists(hostHand, :empty), :ht), guestHand = list_append(if_not_exists(guestHand, :empty), :gt)',
-        ExpressionAttributeValues: marshall({ ':b': newBunch, ':empty': [], ':ht': [hostTile], ':gt': [guestTile] }),
-      }));
+      try {
+        await dynamo.send(new UpdateItemCommand({
+          TableName: GAMES_TABLE,
+          Key: marshall({ roomCode }),
+          UpdateExpression: 'SET bunch = :b, peelVersion = :npv, hostHand = list_append(if_not_exists(hostHand, :empty), :ht), guestHand = list_append(if_not_exists(guestHand, :empty), :gt)',
+          ConditionExpression: 'attribute_not_exists(peelVersion) OR peelVersion = :pv',
+          ExpressionAttributeValues: marshall({ ':b': newBunch, ':empty': [], ':ht': [hostTile], ':gt': [guestTile], ':pv': peelVersion, ':npv': peelVersion + 1 }),
+        }));
+      } catch (err) {
+        // Another concurrent peel already processed — the other Lambda sent PEEL_RESULT to both players
+        if (err.name === 'ConditionalCheckFailedException') return { statusCode: 200 };
+        throw err;
+      }
 
       await send(hostConnectionId,  { type: 'PEEL_RESULT', tile: hostTile,  bunchSize: newBunch.length, initiator: role });
       await send(guestConnectionId, { type: 'PEEL_RESULT', tile: guestTile, bunchSize: newBunch.length, initiator: role });
@@ -265,6 +282,10 @@ exports.handler = async (event) => {
       if (!game || game.status !== 'playing') return { statusCode: 200 };
 
       const callerConnId = role === 'host' ? game.hostConnectionId : game.guestConnectionId;
+
+      // Verify the caller is who they claim to be
+      if (connectionId !== callerConnId) return { statusCode: 200 };
+
       const { bunch } = game;
 
       if (bunch.length < 3) {
@@ -272,10 +293,15 @@ exports.handler = async (event) => {
         return { statusCode: 200 };
       }
 
+      const callerHand = (role === 'host' ? game.hostHand : game.guestHand) || [];
+      if (!callerHand.some(t => t.id === tile?.id)) {
+        await send(callerConnId, { type: 'DUMP_ERROR', reason: 'Tile not in hand.' });
+        return { statusCode: 200 };
+      }
+
       const newTiles = bunch.slice(0, 3);
       const newBunch = shuffle([...bunch.slice(3), tile]);
 
-      const callerHand = (role === 'host' ? game.hostHand : game.guestHand) || [];
       const updatedCallerHand = [...callerHand.filter(t => t.id !== tile.id), ...newTiles];
       const callerHandAttr = role === 'host' ? 'hostHand' : 'guestHand';
 
@@ -314,6 +340,26 @@ exports.handler = async (event) => {
       if (game.status === 'paused' && game.pausedRole && game.pausedRole !== role) {
         await send(connectionId, { type: 'ERROR', message: 'You are not the disconnected player for this room.' });
         return { statusCode: 200 };
+      }
+      // For playing games (missed $disconnect), verify the old connection is actually gone
+      if (game.status === 'playing') {
+        const existingConnId = role === 'host' ? game.hostConnectionId : game.guestConnectionId;
+        if (existingConnId) {
+          let connectionAlive = false;
+          try {
+            await apigw.send(new PostToConnectionCommand({
+              ConnectionId: existingConnId,
+              Data: JSON.stringify({ type: 'PING' }),
+            }));
+            connectionAlive = true;
+          } catch (err) {
+            if (err.$metadata?.httpStatusCode !== 410) throw err;
+          }
+          if (connectionAlive) {
+            await send(connectionId, { type: 'ERROR', message: 'That player is still connected to the game.' });
+            return { statusCode: 200 };
+          }
+        }
       }
 
       const hand = (role === 'host' ? game.hostHand : game.guestHand) || [];

--- a/bananagrams-online/game.js
+++ b/bananagrams-online/game.js
@@ -148,7 +148,6 @@ function OnlineBananagrams() {
   const [bunchSize, setBunchSize] = useState(0);
   const [opponent, setOpponent] = useState({ handSize: 21, wordCount: 0 });
   const [message, setMessage] = useState('');
-  const [showWords, setShowWords] = useState(false);
   const [timer, setTimer] = useState(0);
   const [gameResult, setGameResult] = useState(null); // { winner: 'me'|'them' }
   const [dictionary, setDictionary] = useState(null);
@@ -333,7 +332,10 @@ function OnlineBananagrams() {
         setOpponent({ handSize: 0, wordCount: 0 });
         setMessage('');
         setScreen('playing');
-        startTimer();
+        clearInterval(timerRef.current);
+        const restoredTimer = savedForGrid?.timer || 0;
+        setTimer(restoredTimer);
+        timerRef.current = setInterval(() => setTimer(t => t + 1), 1000);
         startPing();
         break;
       }
@@ -452,7 +454,7 @@ function OnlineBananagrams() {
       if (grid[row][col]) handleTileSelect(grid[row][col], 'grid', { row, col });
       return;
     }
-    if (grid[row][col]) return;
+    if (grid[row][col]) { showMsg('That cell is occupied — tap an empty cell.'); return; }
 
     const newGrid = grid.map(r => [...r]);
     newGrid[row][col] = selected.tile;


### PR DESCRIPTION
## Summary

### Rejoin fix (new)
When the waiting player also disconnects from a `paused` game, the old code marked the game `abandoned` — permanently blocking both players from rejoining. Now instead, the game stays `paused`, `pausedRole` is cleared, and the departing player's `connectionId` is removed. Either player can rejoin once they come back; DynamoDB TTL handles cleanup of games where nobody returns.

### Words panel removed
Removed the words count panel from the bottom of the playing screen.

### Bug fixes from holistic review
- **Security (high)**: `peel` and `dump` verify `connectionId` against the stored game record — clients can no longer spoof their role or claim a win
- **Security (high)**: `dump` validates the dumped tile is actually in the caller's stored hand
- **Security (high)**: `rejoinRoom` probes the existing connection before allowing a `playing`-game rejoin; a live connection blocks the attempt
- **Concurrency (medium)**: `peel` uses a `peelVersion` counter to prevent tile duplication from concurrent Lambda invocations
- **Correctness (low)**: `createRoom` validates the second generated room code before writing
- **Correctness (low)**: `REJOIN_OK` restores the elapsed timer from localStorage instead of resetting to 0
- **UX (low)**: tapping an occupied grid cell shows a message instead of silently doing nothing
- **Code quality**: removed dead `showWords`/`setShowWords` state

## Test plan

- [ ] Both players disconnect mid-game and both can rejoin afterward
- [ ] Only one player disconnects — the game resumes correctly when they rejoin
- [ ] Host and guest play a full game — PEEL and DUMP work correctly
- [ ] Dumping a tile ID not in hand returns `DUMP_ERROR`
- [ ] Disconnect and reconnect — timer resumes from where it left off
- [ ] Tapping an occupied grid cell shows the "occupied" message
- [ ] `npm test` in `backend/` — 60 tests passing, branch coverage ≥ 80%

https://claude.ai/code/session_014Dg8aB1HrewQySNduVHBn7