### PR TITLE
fix(bananagrams-online): fix rejoin after both players disconnect + r…

### DIFF
--- a/backend/__tests__/handler.test.js
+++ b/backend/__tests__/handler.test.js
@@ -133,7 +133,7 @@ describe('$disconnect', () => {
     expect(vals[':pr']).toEqual({ S: 'host' });
   });
 
-  test('marks game abandoned when second player disconnects from an already-paused game', async () => {
+  test('keeps game paused and clears waiting player connectionId when second player disconnects', async () => {
     ddbMock
       .on(GetItemCommand)
       .resolvesOnce({ Item: marshalConn({ connectionId: 'guest-conn', roomCode: 'ROOM01', role: 'guest' }) })
@@ -143,13 +143,15 @@ describe('$disconnect', () => {
 
     await handler(event('$disconnect', 'guest-conn'));
 
-    // No WebSocket message needed (disconnected player has no live connection)
     expect(apigwMock.commandCalls(PostToConnectionCommand)).toHaveLength(0);
 
     const updates = ddbMock.commandCalls(UpdateItemCommand);
     expect(updates).toHaveLength(1);
-    const vals = updates[0].args[0].input.ExpressionAttributeValues;
-    expect(vals[':s']).toEqual({ S: 'abandoned' });
+    // Should REMOVE pausedRole and guestConnectionId so both players can rejoin
+    const expr = updates[0].args[0].input.UpdateExpression;
+    expect(expr).toMatch(/REMOVE/i);
+    expect(expr).toContain('pausedRole');
+    expect(expr).toContain('guestConnectionId');
   });
 
   test('does not notify anyone if the game is already finished', async () => {

--- a/backend/handler.js
+++ b/backend/handler.js
@@ -106,13 +106,13 @@ exports.handler = async (event) => {
             ExpressionAttributeValues: marshall({ ':s': 'paused', ':pr': conn.role }),
           }));
         } else if (game && game.status === 'paused') {
-          // Both players gone — abandon the game
+          // The waiting player also left. Clear their connectionId and remove pausedRole
+          // so either player can rejoin once they return. TTL handles final cleanup.
+          const connIdAttr = conn.role === 'host' ? 'hostConnectionId' : 'guestConnectionId';
           await dynamo.send(new UpdateItemCommand({
             TableName: GAMES_TABLE,
             Key: marshall({ roomCode: conn.roomCode }),
-            UpdateExpression: 'SET #s = :s',
-            ExpressionAttributeNames: { '#s': 'status' },
-            ExpressionAttributeValues: marshall({ ':s': 'abandoned' }),
+            UpdateExpression: `REMOVE pausedRole, ${connIdAttr}`,
           }));
         }
       }

--- a/bananagrams-online/game.js
+++ b/bananagrams-online/game.js
@@ -616,8 +616,6 @@ function OnlineBananagrams() {
 
   // ── Playing screen ─────────────────────────────────────────────────────────
 
-  const gridWords = getWordsOnGrid(grid);
-
   return (
     <div style={{
       height: '100vh',
@@ -734,27 +732,6 @@ function OnlineBananagrams() {
           })}
         </div>
       </div>
-
-      {/* Words panel — always visible at the bottom when words exist */}
-      {gridWords.length > 0 && (
-        <div style={{
-          background: 'rgba(255,255,255,0.07)', borderRadius: '10px', padding: '7px',
-          display: 'flex', flexWrap: 'wrap', gap: '4px', maxHeight: '56px', overflow: 'auto', flexShrink: 0,
-        }}>
-          {gridWords.map((w, i) => {
-            const valid = dictionary ? dictionary.has(w.word) : false;
-            return (
-              <span key={i} style={{
-                padding: '2px 7px', borderRadius: '4px', fontSize: '0.75rem', fontWeight: '600',
-                background: valid ? 'rgba(46,204,113,0.25)' : 'rgba(231,76,60,0.25)',
-                color: valid ? '#2ecc71' : '#e74c3c',
-              }}>
-                {w.word} {valid ? '✓' : '?'}
-              </span>
-            );
-          })}
-        </div>
-      )}
 
       {/* Bottom bar */}
       <div style={{


### PR DESCRIPTION
…emove words panel

Rejoin fix: when the waiting player also disconnects from a paused game, instead of marking the game 'abandoned' (which permanently blocks rejoin), REMOVE pausedRole and the player's connectionId. The game stays 'paused' so either player can rejoin once they come back; DynamoDB TTL handles final cleanup of truly dead games.

Also remove the words count panel from the bottom of the playing screen.

https://claude.ai/code/session_014Dg8aB1HrewQySNduVHBn7