### PR TITLE
fix(bananagrams-online): fix two bugs causing rejoin to silently fail

### DIFF
--- a/backend/__tests__/handler.test.js
+++ b/backend/__tests__/handler.test.js
@@ -154,6 +154,25 @@ describe('$disconnect', () => {
     expect(expr).toContain('guestConnectionId');
   });
 
+  test('does not re-pause game when the disconnecting connection is no longer the active one', async () => {
+    // Player has already rejoined with a new connection ID ('new-host-conn') but the
+    // delayed $disconnect for the old connection ('host-conn') fires afterwards.
+    ddbMock
+      .on(GetItemCommand)
+      .resolvesOnce({ Item: marshalConn({ connectionId: 'host-conn', roomCode: 'ROOM01', role: 'host' }) })
+      .resolvesOnce({ Item: marshalGame({ status: 'playing', hostConnectionId: 'new-host-conn', guestConnectionId: 'guest-conn' }) })
+      .on(DeleteItemCommand).resolves({});
+
+    await handler(event('$disconnect', 'host-conn'));
+
+    // Opponent must NOT be notified — the host already rejoined
+    expect(apigwMock.commandCalls(PostToConnectionCommand)).toHaveLength(0);
+    // Game must NOT be paused
+    expect(ddbMock.commandCalls(UpdateItemCommand)).toHaveLength(0);
+    // Stale connection record should still be cleaned up
+    expect(ddbMock.commandCalls(DeleteItemCommand)).toHaveLength(1);
+  });
+
   test('does not notify anyone if the game is already finished', async () => {
     ddbMock
       .on(GetItemCommand)
@@ -619,6 +638,24 @@ describe('rejoinRoom', () => {
     apigwMock
       .on(PostToConnectionCommand)
       .rejectsOnce(Object.assign(new Error('Gone'), { $metadata: { httpStatusCode: 410 } }))
+      .resolves({});
+    ddbMock
+      .on(GetItemCommand).resolves({ Item: pausedGame({ status: 'playing', pausedRole: null }) })
+      .on(UpdateItemCommand).resolves({});
+
+    await handler(event('$default', 'new-host-conn', { action: 'rejoinRoom', roomCode: 'ROOM01', role: 'host' }));
+
+    const ok = msgsTo('new-host-conn').find(m => m.type === 'REJOIN_OK');
+    expect(ok).toBeDefined();
+    expect(ok.hand).toEqual(HOST_HAND);
+  });
+
+  test('proceeds with rejoin when old connection ping returns a non-410 error', async () => {
+    // API GW can return non-410 codes (403, 404, etc.) for stale/expired connections.
+    // The handler must treat any ping error as "connection dead" rather than crashing.
+    apigwMock
+      .on(PostToConnectionCommand)
+      .rejectsOnce(Object.assign(new Error('Forbidden'), { $metadata: { httpStatusCode: 403 } }))
       .resolves({});
     ddbMock
       .on(GetItemCommand).resolves({ Item: pausedGame({ status: 'playing', pausedRole: null }) })

--- a/backend/handler.js
+++ b/backend/handler.js
@@ -91,20 +91,27 @@ exports.handler = async (event) => {
       if (conn?.roomCode) {
         const game = await getGame(conn.roomCode);
         if (game && game.status === 'playing') {
-          const opponentConnId = conn.role === 'host'
-            ? game.guestConnectionId
-            : game.hostConnectionId;
-          if (opponentConnId) {
-            await send(opponentConnId, { type: 'OPPONENT_DISCONNECTED' });
+          // Only pause when the disconnecting connection is still the active one for its
+          // role. A player may have already rejoined with a new connection ID, in which
+          // case the delayed $disconnect for the old connection must not re-pause the game.
+          const activeConnId = conn.role === 'host'
+            ? game.hostConnectionId
+            : game.guestConnectionId;
+          if (activeConnId === connectionId) {
+            const opponentConnId = conn.role === 'host'
+              ? game.guestConnectionId
+              : game.hostConnectionId;
+            if (opponentConnId) {
+              await send(opponentConnId, { type: 'OPPONENT_DISCONNECTED' });
+            }
+            await dynamo.send(new UpdateItemCommand({
+              TableName: GAMES_TABLE,
+              Key: marshall({ roomCode: conn.roomCode }),
+              UpdateExpression: 'SET #s = :s, pausedRole = :pr',
+              ExpressionAttributeNames: { '#s': 'status' },
+              ExpressionAttributeValues: marshall({ ':s': 'paused', ':pr': conn.role }),
+            }));
           }
-          // Mark game paused so the opponent waits while the player can rejoin
-          await dynamo.send(new UpdateItemCommand({
-            TableName: GAMES_TABLE,
-            Key: marshall({ roomCode: conn.roomCode }),
-            UpdateExpression: 'SET #s = :s, pausedRole = :pr',
-            ExpressionAttributeNames: { '#s': 'status' },
-            ExpressionAttributeValues: marshall({ ':s': 'paused', ':pr': conn.role }),
-          }));
         } else if (game && game.status === 'paused') {
           // The waiting player also left. Clear their connectionId and remove pausedRole
           // so either player can rejoin once they return. TTL handles final cleanup.
@@ -352,8 +359,10 @@ exports.handler = async (event) => {
               Data: JSON.stringify({ type: 'PING' }),
             }));
             connectionAlive = true;
-          } catch (err) {
-            if (err.$metadata?.httpStatusCode !== 410) throw err;
+          } catch {
+            // Any error (410 Gone, 403, 404, etc.) means the connection is dead.
+            // Do NOT rethrow — a non-410 code must not crash the handler and leave
+            // the rejoining client hanging with no response.
           }
           if (connectionAlive) {
             await send(connectionId, { type: 'ERROR', message: 'That player is still connected to the game.' });


### PR DESCRIPTION
Bug 1 — non-410 ping error crashes Lambda with no response:
In rejoinRoom, pinging the old connection to check liveness used to
rethrow any error that wasn't exactly 410. API Gateway can return 403,
404, or other codes for stale/expired connections, causing the Lambda to
return 500 without sending any WebSocket message. The client would wait
8 s and display "No response from the server — the session may have
expired." Fix: treat any ping error as "connection dead" and proceed.

Bug 2 — delayed $disconnect re-pauses a game that was already rejoined:
When a player reconnects quickly, the $disconnect Lambda for the old
connection can fire after rejoinRoom has already set the game back to
'playing' with the new connection ID. Without a guard, $disconnect would
see game.status='playing', notify the opponent with OPPONENT_DISCONNECTED,
and mark the game 'paused' again — leaving the rejoining player on the
playing screen but with a server that silently ignores all PEEL/DUMP
actions. Fix: only pause the game when the disconnecting connection ID
matches the currently-active connection ID for that role.

https://claude.ai/code/session_013RwCDbo3P2EDEuhkn8R188