### PR TITLE
Fix rejoin restoring full dealt hand instead of unplaced hand

### DIFF
--- a/bananagrams-online/game.js
+++ b/bananagrams-online/game.js
@@ -332,17 +332,19 @@ function OnlineBananagrams() {
       case 'REJOIN_OK': {
         setRole(data.role);
         roleRef.current = data.role;
-        // Use hand from server (authoritative); fall back to locally-saved hand
-        const restoredHand = data.hand?.length > 0 ? data.hand : (loadOnlineState()?.hand || []);
-        setHand(restoredHand);
-        handRef.current = restoredHand;
         setBunchSize(data.bunchSize);
         if (data.roomCode) { setRoomCode(data.roomCode); roomRef.current = data.roomCode; }
         // Restore grid from localStorage (only the client knows where tiles were placed)
-        const savedForGrid = loadOnlineState();
-        const restoredGrid = savedForGrid?.grid || createEmptyGrid();
+        const savedState = loadOnlineState();
+        const restoredGrid = savedState?.grid || createEmptyGrid();
         setGrid(restoredGrid);
         gridRef.current = restoredGrid;
+        // The server tracks all tiles ever dealt (never removes placed tiles).
+        // Derive the actual unplaced hand by subtracting tiles already on the grid.
+        const gridTileIds = new Set(restoredGrid.flat().filter(Boolean).map(t => t.id));
+        const restoredHand = (data.hand || []).filter(t => !gridTileIds.has(t.id));
+        setHand(restoredHand);
+        handRef.current = restoredHand;
         setSelected(null);
         setGameResult(null);
         setOpponent({ handSize: 0, wordCount: 0 });
@@ -351,7 +353,7 @@ function OnlineBananagrams() {
         pendingTauntRef.current = null;
         setScreen('playing');
         clearInterval(timerRef.current);
-        const restoredTimer = savedForGrid?.timer || 0;
+        const restoredTimer = savedState?.timer || 0;
         setTimer(restoredTimer);
         timerRef.current = setInterval(() => setTimer(t => t + 1), 1000);
         startPing();


### PR DESCRIPTION
The server's hostHand/guestHand accumulates every tile ever dealt (initial 21 + one per peel) but never removes tiles the player places on the grid, since grid state is client-side only. On rejoin, using that hand directly restores all dealt tiles regardless of what's already on the grid.

Fix: restore the grid from localStorage first, collect its tile IDs into a Set, then filter the server hand down to tiles not present in the grid. This correctly reconstructs the unplaced hand in all cases (mid-game disconnect, disconnect between peel request and PEEL_RESULT, etc.).

https://claude.ai/code/session_013RwCDbo3P2EDEuhkn8R188